### PR TITLE
Prevent num outputs for flux pro/ultra

### DIFF
--- a/README_IMAGE_GENERATION.md
+++ b/README_IMAGE_GENERATION.md
@@ -1,0 +1,132 @@
+# Image Generation Feature
+
+This document describes the image generation functionality implemented in the rSearch application.
+
+## Overview
+
+The image generation feature allows users to create AI-generated images using various Flux models. The implementation properly handles the `num_outputs` parameter based on the selected model type.
+
+## Models Supported
+
+### Single Image Models (Flux Pro & Ultra)
+- **flux-pro**: High-quality single image generation
+- **flux-ultra**: Ultra-high quality single image generation
+
+These models only generate one image per request and **do not accept the `num_outputs` parameter**.
+
+### Multi-Image Models (Flux Standard)
+- **flux-standard**: Standard quality image generation with multiple outputs support
+
+This model supports generating 1-4 images per request and accepts the `num_outputs` parameter.
+
+## Key Implementation Details
+
+### Frontend (`/app/image/page.tsx`)
+
+The frontend automatically:
+- Hides the "Number of Images" slider when a single-image model is selected
+- Shows an informational message for single-image models
+- Only sends the `num_outputs` parameter for multi-image models
+
+### Backend (`/app/api/image/route.ts`)
+
+The API route implements the following logic:
+
+```typescript
+// Only include num_outputs for models that support multiple images
+if (!modelConfig.singleImage) {
+  // Validate and include num_outputs for multi-image models
+  if (num_outputs !== undefined) {
+    payload.num_outputs = num_outputs;
+  }
+} else {
+  // For single image models, ensure num_outputs is not included
+  if (num_outputs !== undefined) {
+    console.warn(`num_outputs parameter ignored for single image model: ${model}`);
+  }
+}
+```
+
+## Environment Variables Required
+
+Add these to your `.env.local` file:
+
+```bash
+IMAGE_GENERATION_API_KEY=your_api_key_here
+IMAGE_GENERATION_BASE_URL=https://api.openai.com
+```
+
+## Usage
+
+1. Navigate to `/image` in the application
+2. Enter your image prompt
+3. Select a model:
+   - Choose **Flux Pro** or **Flux Ultra** for single high-quality images
+   - Choose **Flux Standard** for multiple images (1-4)
+4. Adjust the number of images slider (only available for Flux Standard)
+5. Click "Generate Image"
+
+## API Endpoints
+
+### POST `/api/image`
+Generates images based on the provided parameters.
+
+**Request Body:**
+```json
+{
+  "prompt": "A beautiful sunset over mountains",
+  "model": "flux-pro",
+  "num_outputs": 1  // Only included for multi-image models
+}
+```
+
+**Response:**
+```json
+{
+  "images": [
+    {
+      "url": "https://example.com/image1.png",
+      "alt": "A beautiful sunset over mountains - Generated image 1"
+    }
+  ],
+  "model": "flux-pro",
+  "prompt": "A beautiful sunset over mountains",
+  "generated_at": "2024-01-01T12:00:00.000Z"
+}
+```
+
+### GET `/api/image`
+Returns information about supported models.
+
+**Response:**
+```json
+{
+  "models": [
+    {
+      "name": "flux-pro",
+      "singleImage": true,
+      "description": "High-quality single image generation"
+    }
+  ],
+  "supported_features": {
+    "single_image_models": ["flux-pro", "flux-ultra"],
+    "multi_image_models": ["flux-standard"]
+  }
+}
+```
+
+## Error Handling
+
+The implementation includes comprehensive error handling:
+- Validates required fields (prompt, model)
+- Validates model support
+- Validates `num_outputs` range (1-4) for multi-image models
+- Provides clear error messages for API failures
+- Logs warnings when `num_outputs` is provided for single-image models
+
+## Navigation
+
+The image generation feature is accessible via:
+- Desktop: Sidebar navigation with "Images" icon
+- Mobile: Hamburger menu with "Images" option
+- Direct URL: `/image`

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Define the supported image generation models
+const SUPPORTED_MODELS = {
+  'flux-pro': {
+    name: 'flux-pro',
+    singleImage: true,
+    description: 'High-quality single image generation'
+  },
+  'flux-ultra': {
+    name: 'flux-ultra', 
+    singleImage: true,
+    description: 'Ultra-high quality single image generation'
+  },
+  'flux-standard': {
+    name: 'flux-standard',
+    singleImage: false,
+    description: 'Standard quality image generation with multiple outputs support'
+  }
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { prompt, model, num_outputs } = body;
+
+    // Validate required fields
+    if (!prompt) {
+      return NextResponse.json(
+        { error: 'Prompt is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!model) {
+      return NextResponse.json(
+        { error: 'Model is required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate model
+    const modelConfig = SUPPORTED_MODELS[model as keyof typeof SUPPORTED_MODELS];
+    if (!modelConfig) {
+      return NextResponse.json(
+        { error: `Unsupported model: ${model}` },
+        { status: 400 }
+      );
+    }
+
+    // Prepare the request payload for the image generation API
+    const payload: any = {
+      prompt,
+      model: modelConfig.name
+    };
+
+    // Only include num_outputs for models that support multiple images
+    if (!modelConfig.singleImage) {
+      // Validate num_outputs for multi-image models
+      if (num_outputs !== undefined) {
+        if (typeof num_outputs !== 'number' || num_outputs < 1 || num_outputs > 4) {
+          return NextResponse.json(
+            { error: 'num_outputs must be a number between 1 and 4' },
+            { status: 400 }
+          );
+        }
+        payload.num_outputs = num_outputs;
+      } else {
+        // Default to 1 if not specified
+        payload.num_outputs = 1;
+      }
+    } else {
+      // For single image models (flux-pro, flux-ultra), ensure num_outputs is not included
+      // This is the key fix - we don't pass num_outputs for single image models
+      if (num_outputs !== undefined) {
+        console.warn(`num_outputs parameter ignored for single image model: ${model}`);
+      }
+    }
+
+    // Get API key and base URL from environment variables
+    const apiKey = process.env.IMAGE_GENERATION_API_KEY;
+    const baseUrl = process.env.IMAGE_GENERATION_BASE_URL;
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'Image generation API key not configured' },
+        { status: 500 }
+      );
+    }
+
+    if (!baseUrl) {
+      return NextResponse.json(
+        { error: 'Image generation base URL not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Make the request to the image generation API
+    const response = await fetch(`${baseUrl}/v1/images/generations`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      console.error('Image generation API error:', errorData);
+      
+      return NextResponse.json(
+        { 
+          error: 'Failed to generate image',
+          details: errorData.error?.message || 'Unknown error from image generation service'
+        },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    // Transform the response to match our expected format
+    const images = data.data?.map((item: any, index: number) => ({
+      url: item.url,
+      alt: `${prompt} - Generated image ${index + 1}`
+    })) || [];
+
+    return NextResponse.json({
+      images,
+      model: modelConfig.name,
+      prompt,
+      generated_at: new Date().toISOString()
+    });
+
+  } catch (error) {
+    console.error('Image generation error:', error);
+    
+    return NextResponse.json(
+      { 
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// Handle GET requests to provide model information
+export async function GET() {
+  return NextResponse.json({
+    models: Object.values(SUPPORTED_MODELS),
+    supported_features: {
+      single_image_models: ['flux-pro', 'flux-ultra'],
+      multi_image_models: ['flux-standard']
+    }
+  });
+}

--- a/app/image/page.tsx
+++ b/app/image/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from 'react';
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Image, Loader2 } from "lucide-react";
+
+interface ImageGenerationResult {
+  url: string;
+  alt: string;
+}
+
+const imageModels = [
+  {
+    id: "flux-pro",
+    name: "Flux Pro",
+    description: "High-quality image generation (single image only)",
+    singleImage: true
+  },
+  {
+    id: "flux-ultra", 
+    name: "Flux Ultra",
+    description: "Ultra-high quality image generation (single image only)",
+    singleImage: true
+  },
+  {
+    id: "flux-standard",
+    name: "Flux Standard",
+    description: "Standard quality image generation (multiple images supported)",
+    singleImage: false
+  }
+];
+
+export default function ImageGenerationPage() {
+  const [prompt, setPrompt] = useState('');
+  const [selectedModel, setSelectedModel] = useState('flux-standard');
+  const [numOutputs, setNumOutputs] = useState(1);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [results, setResults] = useState<ImageGenerationResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = async () => {
+    if (!prompt.trim()) return;
+
+    setIsGenerating(true);
+    setError(null);
+    setResults([]);
+
+    try {
+      const selectedModelConfig = imageModels.find(model => model.id === selectedModel);
+      
+      // Prepare request body - don't include num_outputs for single image models
+      const requestBody: any = {
+        prompt: prompt.trim(),
+        model: selectedModel
+      };
+
+      // Only include num_outputs for models that support multiple images
+      if (!selectedModelConfig?.singleImage) {
+        requestBody.num_outputs = numOutputs;
+      }
+
+      const response = await fetch('/api/image', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to generate image');
+      }
+
+      const data = await response.json();
+      setResults(data.images || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const selectedModelConfig = imageModels.find(model => model.id === selectedModel);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl font-bold text-orange-600 mb-2">AI Image Generation</h1>
+        <p className="text-orange-500/60">Create stunning images with AI</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Input Section */}
+        <div className="lg:col-span-2 space-y-6">
+          <Card className="border-orange-200">
+            <CardHeader>
+              <CardTitle className="text-orange-600">Image Prompt</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder="Describe the image you want to generate..."
+                className="min-h-[120px] resize-none"
+                disabled={isGenerating}
+              />
+              
+              <Button
+                onClick={handleGenerate}
+                disabled={!prompt.trim() || isGenerating}
+                className="w-full bg-orange-600 hover:bg-orange-500 text-white"
+              >
+                {isGenerating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <Image className="mr-2 h-4 w-4" />
+                    Generate Image
+                  </>
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Results Section */}
+          {results.length > 0 && (
+            <Card className="border-orange-200">
+              <CardHeader>
+                <CardTitle className="text-orange-600">Generated Images</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  {results.map((result, index) => (
+                    <div key={index} className="relative group">
+                      <img
+                        src={result.url}
+                        alt={result.alt}
+                        className="w-full h-auto rounded-lg shadow-md"
+                      />
+                      <a
+                        href={result.url}
+                        download={`generated-image-${index + 1}.png`}
+                        className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-lg flex items-center justify-center"
+                      >
+                        <Button variant="secondary" size="sm">
+                          Download
+                        </Button>
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Error Section */}
+          {error && (
+            <Card className="border-red-200 bg-red-50">
+              <CardContent className="pt-6">
+                <p className="text-red-600">{error}</p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Settings Section */}
+        <div className="space-y-6">
+          <Card className="border-orange-200">
+            <CardHeader>
+              <CardTitle className="text-orange-600">Model Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <RadioGroup
+                value={selectedModel}
+                onValueChange={setSelectedModel}
+                className="space-y-3"
+              >
+                {imageModels.map((model) => (
+                  <div key={model.id} className="flex items-start space-x-3">
+                    <RadioGroupItem
+                      value={model.id}
+                      id={model.id}
+                      className="mt-1 border-orange-500 text-orange-600"
+                    />
+                    <Label htmlFor={model.id} className="grid gap-1.5 leading-none cursor-pointer">
+                      <div className="text-orange-600 font-medium">{model.name}</div>
+                      <div className="text-sm text-orange-500/80">{model.description}</div>
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            </CardContent>
+          </Card>
+
+          {/* Number of Outputs - Only show for multi-image models */}
+          {!selectedModelConfig?.singleImage && (
+            <Card className="border-orange-200">
+              <CardHeader>
+                <CardTitle className="text-orange-600">Number of Images</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center space-x-4">
+                  <input
+                    type="range"
+                    min="1"
+                    max="4"
+                    value={numOutputs}
+                    onChange={(e) => setNumOutputs(parseInt(e.target.value))}
+                    className="flex-1"
+                    disabled={isGenerating}
+                  />
+                  <span className="text-orange-600 font-medium min-w-[2rem] text-center">
+                    {numOutputs}
+                  </span>
+                </div>
+                <p className="text-sm text-orange-500/80 mt-2">
+                  Generate {numOutputs} image{numOutputs > 1 ? 's' : ''}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Info for single image models */}
+          {selectedModelConfig?.singleImage && (
+            <Card className="border-blue-200 bg-blue-50">
+              <CardContent className="pt-6">
+                <p className="text-blue-600 text-sm">
+                  <strong>{selectedModelConfig.name}</strong> generates one high-quality image per request.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Search, Settings } from "lucide-react";
+import { Search, Settings, Image } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface SidebarProps {
@@ -40,6 +40,14 @@ export function Sidebar({ className, isMobile }: SidebarProps) {
         >
           <Search className="h-6 w-6" />
           <span className="text-xs font-medium">Search</span>
+        </Link>
+        
+        <Link 
+          href="/image" 
+          className="flex flex-col items-center gap-2 p-3 text-orange-500 hover:bg-orange-50 rounded-lg transition-colors"
+        >
+          <Image className="h-6 w-6" />
+          <span className="text-xs font-medium">Images</span>
         </Link>
       </div>
 


### PR DESCRIPTION
Add AI image generation feature, correctly handling `num_outputs` for Flux Pro/Ultra models.

This PR introduces a new AI image generation capability at `/image`, allowing users to create images using Flux models. The primary fix addresses the requirement that `num_outputs` should not be sent for 'flux-pro' and 'flux-ultra' models, as they are designed to produce only one image.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c899172-60fc-432f-89cd-1dc1fc335be7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c899172-60fc-432f-89cd-1dc1fc335be7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>