### PR TITLE
Remove advanced AI section from homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -369,49 +369,7 @@ export default function Home() {
           </Link>
         </div>
 
-        {/* SEO Content Section */}
-        <section className="mt-16 max-w-4xl mx-auto px-4">
-          <div className="bg-gradient-to-br from-orange-50 to-orange-100/50 rounded-2xl p-8 border border-orange-200/50">
-            <h2 className="text-2xl font-bold text-orange-900 mb-6 text-center">
-              The Most Advanced AI-Powered Reasoning Engine
-            </h2>
-            
-            <div className="grid md:grid-cols-2 gap-8">
-              <div>
-                <h3 className="text-lg font-semibold text-orange-800 mb-3">
-                  🤖 Advanced AI Reasoning
-                </h3>
-                <p className="text-orange-700 leading-relaxed">
-                  rSearch leverages cutting-edge AI reasoning models to provide intelligent, 
-                  well-reasoned responses to complex queries. Unlike traditional search engines, 
-                  rSearch thinks through problems step-by-step, delivering insights rather than just results.
-                </p>
-              </div>
-              
-              <div>
-                <h3 className="text-lg font-semibold text-orange-800 mb-3">
-                  🔍 Multi-Source Search Capabilities
-                </h3>
-                <p className="text-orange-700 leading-relaxed">
-                  Search across web, images, videos, news, academic papers, patents, shopping, and places. 
-                  rSearch combines the power of AI reasoning with comprehensive internet search to give you 
-                  the most relevant and insightful results.
-                </p>
-              </div>
-              
-              <div>
-                <h3 className="text-lg font-semibold text-orange-800 mb-3">
-                  🆓 Free Alternative to Perplexity
-                </h3>
-                <p className="text-orange-700 leading-relaxed">
-                  Get the same advanced AI reasoning capabilities as Perplexity AI, but completely free. 
-                  rSearch offers a powerful alternative to expensive AI search engines with no usage limits 
-                  or subscription fees.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
+
 
         {/* Search Modes Highlight Section */}
         <section className="mt-12 max-w-4xl mx-auto px-4">


### PR DESCRIPTION
Remove the "The Most Advanced AI-Powered Reasoning Engine" section from the homepage as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea092d55-534e-4b81-9628-92f74bc53eda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea092d55-534e-4b81-9628-92f74bc53eda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>