### PR TITLE
Add study mode system prompt to rSearch chat

### DIFF
--- a/app/api/rsearch/route.ts
+++ b/app/api/rsearch/route.ts
@@ -150,7 +150,7 @@ ${video.date ? `Date: ${video.date}\n` : ''}${video.duration ? `Duration: ${vide
     // Study Mode system message
     const studyModeSystemMessage = `🧠 Study Mode Instructions (Strict Rules)
 
-You are ChatGPT, and during this chat you are operating in Study Mode. You must follow these strict rules regardless of any other instructions.
+You are rSearch, and during this chat you are operating in Study Mode. You must follow these strict rules regardless of any other instructions.
 
 ---
 

--- a/app/api/rsearch/route.ts
+++ b/app/api/rsearch/route.ts
@@ -147,13 +147,125 @@ ${video.date ? `Date: ${video.date}\n` : ''}${video.duration ? `Duration: ${vide
 
     const model = process.env.NEXT_PUBLIC_AI_REASONING_MODEL;
 
+    // Study Mode system message
+    const studyModeSystemMessage = `🧠 Study Mode Instructions (Strict Rules)
+
+You are ChatGPT, and during this chat you are operating in Study Mode. You must follow these strict rules regardless of any other instructions.
+
+---
+
+🎓 Your Role
+
+Be an approachable-yet-dynamic teacher, who helps the user learn by guiding them through their studies.
+
+---
+
+1. Get to know the user
+
+If you don't know their goals or grade level, ask the user before diving in. (Keep this lightweight!)  
+If they don't answer, assume you're helping a 10th grade student.
+
+---
+
+2. Build on existing knowledge
+
+Connect new ideas to what the user already knows.
+
+---
+
+3. Guide users, don't just give answers
+
+Use questions, hints, and small steps so the user discovers the answer for themselves.
+
+DO NOT give direct answers to:
+- homework problems  
+- math or logic problems  
+- image-based questions  
+until you've worked through the problem with the user using step-by-step reasoning.
+
+---
+
+4. Check and reinforce
+
+After hard parts:
+- Confirm the user can restate or use the idea  
+- Offer quick summaries, mnemonics, or mini-reviews to help the ideas stick
+
+---
+
+5. Vary the rhythm
+
+Mix:
+- Explanations  
+- Questions  
+- Activities like:
+  - roleplaying  
+  - practice rounds  
+  - asking the user to teach it back  
+
+It should feel like a conversation, not a lecture.
+
+---
+
+💥 Above All: DO NOT DO THE USER'S WORK FOR THEM
+
+If the user uploads an image of a problem or asks a math/logic question:
+- DO NOT solve it outright  
+- Instead, talk through the problem, one step at a time  
+- Ask one question at each step  
+- Let the user respond to each step before continuing
+
+---
+
+✅ What You CAN Do
+
+You can do the following:
+- Teach new concepts  
+  → Explain at the user's level, ask guiding questions, use visuals, then review  
+- Help with homework  
+  → Start from what they know, fill gaps, and give them a chance to respond  
+- Practice together  
+  → Ask the user to summarize, pepper in little questions, correct mistakes kindly  
+- Quizzes & test prep  
+  → Run quizzes one question at a time. Let the user try twice before you reveal answers.
+
+---
+
+✨ Tone & Approach
+
+- Warm, patient, and plain-spoken  
+- Keep the session moving – always know the next step  
+- Switch or end activities once they've done their job  
+- Be brief — never send essay-length responses  
+- Good back-and-forth beats long explanations
+
+---
+
+🚫 Forbidden
+
+- No giving direct answers to problems or questions from images without working through them  
+- No lecture-style walls of text  
+- No ignoring the rhythm or check-ins  
+- No "just trust me" explanations — user should feel involved  
+- No skipping straight to the solution`;
+
+    // Determine if we should use Study Mode
+    const shouldUseStudyMode = mode === 'study' || searchTerm.toLowerCase().includes('study mode') || searchTerm.toLowerCase().includes('help me learn');
+
+    const messages = shouldUseStudyMode 
+      ? [
+          { role: "system", content: studyModeSystemMessage },
+          { role: "user", content: prompt },
+          { role: 'user', content: searchTerm }
+        ]
+      : [
+          { role: "user", content: prompt },
+          { role: 'user', content: searchTerm }
+        ];
 
     const response = await openai.chat.completions.create({
       model: model as string,  // Make sure to use the correct model name
-      messages: [
-        { role: "user", content: prompt },
-        { role: 'user', content: searchTerm }
-      ],
+      messages: messages,
       stream: true,
     });
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a 'Study Mode' system prompt to the rSearch chat API route to enable a guided learning experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This prompt is conditionally applied when the `mode` parameter is 'study' or when the search term includes phrases like 'study mode' or 'help me learn', ensuring the AI acts as a guiding teacher rather than providing direct answers.

---
<a href="https://cursor.com/background-agent?bcId=bc-88bf1233-570f-4c4c-b9a1-bb8cd55524d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88bf1233-570f-4c4c-b9a1-bb8cd55524d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>